### PR TITLE
fix:fixed make install is not installing the binary correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,10 @@ $(JS_BUILD_OUTPUT): $(JS_SOURCES)
 	@cd js && bun install && bun run build
 
 .PHONY: install
-install: ## install golang binary
-	@go install -ldflags "-X main.version=$(shell git describe --abbrev=0 --tags)"
+install: build ## install binary to /usr/local/bin
+	@echo "--> Installing cligram to /usr/local/bin..."
+	@sudo cp $(projectname) /usr/local/bin/
+	@echo "--> Installation complete. Run 'cligram' to start."
 
 .PHONY: run
 run: build ## build and run the app


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the installation process to provide clearer user messages and install the binary to `/usr/local/bin` with improved feedback during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->