### PR TITLE
chore: update docker GitHub workflow to trigger on version tags inste…

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -2,8 +2,8 @@ name: Publish cligram Docker Image
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'v*'
 
 jobs:
   build:


### PR DESCRIPTION
…ad of branch pushes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Docker image publishing workflow to run only when version tags (v*) are pushed, ensuring images are released alongside tagged versions.
  - Build and push steps remain the same; no impact on app functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->