### PR TITLE
fix: show this message is not support by this client indicator

### DIFF
--- a/internal/telegram/chat/manager.go
+++ b/internal/telegram/chat/manager.go
@@ -366,6 +366,7 @@ func (m *Manager) getAllDialogs(ctx context.Context, offsetDate, offsetID int) (
 			}, nil
 		}
 		last := d.Messages[len(d.Messages)-1]
+
 		switch msg := last.(type) {
 		case *tg.Message:
 			return &CligramGetDialogsResponse{

--- a/internal/telegram/client/auth.go
+++ b/internal/telegram/client/auth.go
@@ -136,6 +136,8 @@ func (a *authFlow) Password(_ context.Context) (string, error) {
 	return strings.TrimSpace(string(b)), nil
 }
 
+// we won't use this function telegram doesn't allow us to sign up from unnoficial clients but the gotd/td
+// but auth.NewFlow function requires to implent this method so let's keeps it
 func (a *authFlow) SignUp(_ context.Context) (auth.UserInfo, error) {
 	fmt.Print("Enter first name: ")
 	first, _ := bufio.NewReader(os.Stdin).ReadString('\n')

--- a/internal/telegram/shared/shared.go
+++ b/internal/telegram/shared/shared.go
@@ -60,14 +60,22 @@ func FormatMessage[T ChannelOrUser](msg *tg.Message, userOrChannel *T, allMessag
 		}
 	}
 
+	isUnsupportedMessage := msg.Media != nil
+
+	var content = msg.Message
+
+	if isUnsupportedMessage {
+		content = "This Message is not supported by this Telegram client."
+	}
+
 	return &types.FormattedMessage{
 		ID:                   msg.ID,
 		Sender:               sender,
-		Content:              msg.Message,
+		Content:              content,
 		IsFromMe:             msg.Out,
 		Media:                nil,
 		Date:                 time.Unix(int64(msg.Date), 0),
-		IsUnsupportedMessage: false,
+		IsUnsupportedMessage: isUnsupportedMessage,
 		WebPage:              nil,
 		Document:             nil,
 		FromID:               FromID,

--- a/internal/ui/update-ui.go
+++ b/internal/ui/update-ui.go
@@ -457,7 +457,6 @@ func (m Model) handleListPagination() (Model, tea.Cmd) {
 	if m.Users.Index() < len(m.Users.VisibleItems())-6 {
 		return m, nil
 	}
-
 	if m.OffsetDate == -1 || m.OffsetID == -1 {
 		return m, nil
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added interactive sign-up flow that prompts for first and last name when required, ensuring smoother account setup.
  - Improved chat clarity: messages with unsupported media now show a standard placeholder and are flagged as unsupported, instead of displaying raw/empty content.

- Style
  - Minor whitespace and formatting cleanups in chat and UI update logic; no impact on functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->