### PR TITLE
Fix/pagination multple request

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,6 +122,8 @@ func newRootCmd(version string) *cobra.Command {
 				model.SelectedFile = ""
 				model.OffsetDate = userChatsResult.OffsetDate
 				model.OffsetID = userChatsResult.OffsetID
+				model.OnPagination = false
+
 				model.Stories = []types.Stories{}
 
 				background := model

--- a/internal/telegram/chat/manager.go
+++ b/internal/telegram/chat/manager.go
@@ -3,11 +3,9 @@ package chat
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"slices"
 	"strconv"
-	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gotd/td/tg"
@@ -335,7 +333,6 @@ func (m *Manager) getAllDialogs(ctx context.Context, offsetDate, offsetID int) (
 		slog.Error(err.Error())
 		return nil, err
 	}
-
 	switch d := dialogs.(type) {
 	case *tg.MessagesDialogs:
 		allChats = append(allChats, d.Chats...)
@@ -363,7 +360,6 @@ func (m *Manager) getAllDialogs(ctx context.Context, offsetDate, offsetID int) (
 			}, nil
 		}
 		last := d.Messages[len(d.Messages)-1]
-
 		switch msg := last.(type) {
 		case *tg.Message:
 			return &CligramGetDialogsResponse{
@@ -375,12 +371,13 @@ func (m *Manager) getAllDialogs(ctx context.Context, offsetDate, offsetID int) (
 			}, nil
 		default:
 			return &CligramGetDialogsResponse{
-				Chats:   allChats,
-				Users:   allUsers,
-				Dialogs: allDialogs,
+				Chats:      allChats,
+				Users:      allUsers,
+				Dialogs:    allDialogs,
+				OffsetDate: -1,
+				OffsetID:   -1,
 			}, nil
 		}
-
 	default:
 		return &CligramGetDialogsResponse{
 			Chats:      allChats,
@@ -434,51 +431,4 @@ func convertPeerToInputPeer(peer types.Peer) (tg.InputPeerClass, error) {
 type userOnlineStatus struct {
 	IsOnline bool
 	LastSeen *string
-}
-
-func getUserOnlineStatus(status tg.UserStatusClass) *userOnlineStatus {
-	if status == nil {
-		return &userOnlineStatus{
-			IsOnline: false,
-			LastSeen: nil,
-		}
-	}
-	switch s := status.(type) {
-	case *tg.UserStatusOnline:
-		lastSeen := "online"
-		return &userOnlineStatus{
-			IsOnline: true,
-			LastSeen: &lastSeen,
-		}
-	case *tg.UserStatusOffline:
-		lastSeen := calculateLastSeenHumanReadable(s.WasOnline)
-		return &userOnlineStatus{
-			IsOnline: false,
-			LastSeen: &lastSeen,
-		}
-	default:
-		lastSeen := "last seen long time ago"
-		return &userOnlineStatus{
-			IsOnline: false,
-			LastSeen: &lastSeen,
-		}
-	}
-}
-
-func calculateLastSeenHumanReadable(wasOnline int) string {
-	lastSeenTime := time.Unix(int64(wasOnline), 0)
-	currentTime := time.Now()
-	diff := currentTime.Sub(lastSeenTime)
-
-	if diff.Seconds() < 60 {
-		return "last seen just now"
-	}
-	if diff.Hours() < 24 {
-		return fmt.Sprintf("last seen at %s", lastSeenTime.Format("03:04 PM"))
-	}
-	if diff.Hours() < 48 {
-		return fmt.Sprintf("last seen yesterday at %s", lastSeenTime.Format("03:04 PM"))
-	}
-
-	return fmt.Sprintf("last seen on %s", lastSeenTime.Format("02/01/2006 03:04 PM"))
 }

--- a/internal/ui/modal.go
+++ b/internal/ui/modal.go
@@ -35,6 +35,7 @@ func (m Manager) Init() tea.Cmd {
 }
 
 func (m Manager) Update(message tea.Msg) (tea.Model, tea.Cmd) {
+	var cmds []tea.Cmd
 	switch msg := message.(type) {
 	case tea.WindowSizeMsg:
 		m.WindowWidth = msg.Width
@@ -56,9 +57,15 @@ func (m Manager) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+k":
 			if m.State == MainView {
 				m.State = ModalView
-			} else {
-				m.State = MainView
+				openModalMsg := func() tea.Msg {
+					return OpenModalMsg{
+						ModalMode: ModalModeSearch,
+					}
+				}
+				cmds = append(cmds, openModalMsg)
+				return m, tea.Batch(cmds...)
 			}
+			m.State = MainView
 		case "alt+s":
 			m.State = ModalView
 			bgModel, cmd := m.Background.Update(message)
@@ -68,7 +75,8 @@ func (m Manager) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			m.Background = bgModel
-			return m, tea.Batch(cmd, openModalMsg)
+			cmds = append(cmds, cmd, openModalMsg)
+			return m, tea.Batch(cmds...)
 		}
 		if m.State == ModalView {
 			fg, fgCmd := m.Foreground.Update(message)

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -296,6 +296,7 @@ func changeSideBarMode(m *Model, msg string) (Model, tea.Cmd) {
 	if m.FocusedOn == SideBar {
 		m.ChatUI.ResetSelected()
 		m.AreWeSwitchingModes = true
+		m.OnPagination = false
 	}
 	areWeInGroupMode := m.Mode == ModeGroups && m.FocusedOn == Mainview
 	//i don't think 🤔 we should keep the list in memory

--- a/internal/ui/update-ui.go
+++ b/internal/ui/update-ui.go
@@ -448,9 +448,17 @@ func (m Model) handleListPagination() (Model, tea.Cmd) {
 	if m.Users.Index() < len(m.Users.VisibleItems())-6 {
 		return m, nil
 	}
+
 	if m.OffsetDate == -1 || m.OffsetID == -1 {
 		return m, nil
 	}
+
+	if m.OnPagination {
+		return m, nil
+	}
+
+	m.OnPagination = true
+
 	if m.Mode == ModeUsers || m.Mode == ModeBots {
 		return m, telegram.Cligram.GetUserChats(telegram.Cligram.Context(), types.ChatType(m.Mode), m.OffsetDate, m.OffsetID)
 	}
@@ -578,9 +586,11 @@ func (m Model) handleUserChats(msg types.UserChatsMsg) (tea.Model, tea.Cmd) {
 	}
 	//TODO: reminder to filter out if the chats gets duplicated
 	m.Users.SetItems(users)
+
 	m.AreWeSwitchingModes = false
 	m.OffsetDate = msg.Response.OffsetDate
 	m.OffsetID = msg.Response.OffsetID
+	m.OnPagination = false
 	return m, nil
 }
 
@@ -604,6 +614,7 @@ func (m Model) handleUserChannels(msg types.ChannelsMsg) (tea.Model, tea.Cmd) {
 	m.AreWeSwitchingModes = false
 	m.OffsetDate = msg.Response.OffsetDate
 	m.OffsetID = msg.Response.OffsetID
+	m.OnPagination = false
 	return m, nil
 }
 

--- a/internal/ui/util.go
+++ b/internal/ui/util.go
@@ -129,7 +129,9 @@ type Model struct {
 	EditMessage          *types.FormattedMessage
 	SkipNextInput        bool
 	OffsetDate, OffsetID int
-	Stories              []types.Stories
+	//an indicator that tells there is already on going request kinda debouncing
+	OnPagination bool
+	Stories      []types.Stories
 }
 
 func filterEmptyMessages(msgs [50]types.FormattedMessage) []types.FormattedMessage {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Keyboard shortcuts: Ctrl+K opens the Search modal; Alt+S opens the Stories modal.

- Bug Fixes
  - Prevents duplicate pagination requests for smoother, more reliable list loading.
  - Resets pagination state when switching sidebar modes to avoid stuck or repeated loads.

- Refactor
  - Streamlined chat list data shaping; removed display of online/last-seen status in chats for a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->